### PR TITLE
Add licensee info for carrier boards

### DIFF
--- a/CB_REV_C_Altium/Carrier board footprint approval
+++ b/CB_REV_C_Altium/Carrier board footprint approval
@@ -18,4 +18,5 @@ CB0000006     |Hex                |Philip                       |ProfiCNC.com   
 CB0000007     |VAMATIS            |Nicolas Chaslot              |Vamatis.com        |Mega Solo Carrier board          |ncx94
 CB0000008     |Airbot Systems     |Philip                       |Airbot-systems.com |PDB Carrier Board                |ProfiCNC
 CB0000009     |SpektreWorks       |Daniel Laks                  |spektreworks.com   |Multi-Rotor Carrier Board        |SpektreWorks
-
+CB0000010     |AguaDrone          |Jeff Wurzbach                |aguadrone.com      |AguaDrone Mainboard              |apache405
+CB0000011     |HiTec              |Jeff Wurzbach                |http://hitecnology.com/drones|Xeno Mainboard         |apache405


### PR DESCRIPTION
Added Hitec Commerical Solutions and AguaDrone.