### PR TITLE
aad an entry to carrier board footprint license file

### DIFF
--- a/CB_REV_C_Altium/Carrier board footprint approval
+++ b/CB_REV_C_Altium/Carrier board footprint approval
@@ -34,3 +34,4 @@ CB0000022     |SpektreWorks       |Daniel Laks                  |spektreworks.co
 CB0000023     |SpektreWorks       |Daniel Laks                  |spektreworks.com   |Spektre Carrier Board            |SpektreWorks
 CB0000024     |Real-time Robotics |Quoc Luong                   |rtrobotics.com     |RtR Carrier Board                |RtRobotics
 CB0000025     |IkingTec           |Tang Bo                      |ikingtec.com       |Carrier Board                    |IkingTec
+CB0000026     |NXT Robotics       |Jeff Wurzbach                |nxtrobotics.com    |Rover Carrier Board              |apache405


### PR DESCRIPTION
Add an entry for NXT Robotics's carrier board.