### PR TITLE
Update Carrier board footprint approval

### DIFF
--- a/CB_REV_C_Altium/Carrier board footprint approval
+++ b/CB_REV_C_Altium/Carrier board footprint approval
@@ -42,3 +42,4 @@ CB0000030     |OLLIWprivateINC    |OlliW                        |www.olliw.eu   
 CB0000031     |personal use       |Eugene Zhou                  |---                |custom mini carrier board        |EugeneZhou1018
 CB0000032     |KTS/Aeromorphology||Duane Hill                   |aeromorphology.com |custom carrier board             |aeromorphology
 CB0000033     |Airobot            |Kristof Beenders             |airobot.eu         |custom carrier board             |airobotUAV
+CB0000034     |Airborne Drones    |Matthew Burger               |airbornedrones.co  |Custom carrier board             |AirborneDrones


### PR DESCRIPTION
Requesting license and footprint of the Cube for a custom carrier board.
Use: A full Power distribution board centred around the Cube for easier integration in future projects.