### PR TITLE
Footprint use license request

### DIFF
--- a/CB_REV_C_Altium/Carrier board footprint approval
+++ b/CB_REV_C_Altium/Carrier board footprint approval
@@ -70,3 +70,4 @@ CB0000058     |Artemis Systems    |Devin Freitas                |---            
 CB0000059     |Private            |Thiwanka Jayasiri            |---                |Custom carrier board             |thiwankajayasiri
 CB0000060     |ArclightDS         |Jason Judson                 |---                |Custom Carrier Board             |arclightds
 CB0000061     |VAMUdeS            |Guillaume Giroux             |vamudes.ca         |Custom Carrier Board             |GuillaumeGiroux29
+CB0000062     |Private            |Chris Dycus                  |---                |Custom Carrier Board             |dycus


### PR DESCRIPTION
Requesting to use the Cube board-side (male) connector footprint for a custom carrier board