### PR TITLE
Request a new CarrierBoard Footprint approval Serial Number for uAvionix

### DIFF
--- a/CB_REV_C_Altium/Carrier board footprint approval
+++ b/CB_REV_C_Altium/Carrier board footprint approval
@@ -102,3 +102,4 @@ CB0000090     |ACP Aviation       |Anthony Kirk                 |acpaviation.co.
 CB0000091     |Aerialtronics      |Jeroen Taverne               |aerialtronics.com  |custom Carrier Board             |jeroentaverne
 CB0000092     |Fotoacc Grzegorz Łobodziński | Łukasz Wielgosz   |fotoacc.pl         |custom Carrier Board             |lukaszwielgosz
 CB0000093     |TeamBathDrones     |Freddie Sherratt             |teambathdrones.com |Custom carrier board             |fsherratt
+CB0000094     |uAvionix           |Jeff Walker                  |https://uavionix.com | Custom Carrier Board          |jwuavionix 


### PR DESCRIPTION
I would like to request that serial number CB0000094 be granted to uAvionix to allow the use of The Cube's footprint in our custom carrier board.