### PR TITLE
Update Carrier board footprint approval

### DIFF
--- a/CB_REV_C_Altium/Carrier board footprint approval
+++ b/CB_REV_C_Altium/Carrier board footprint approval
@@ -151,3 +151,4 @@ CB0000130     |SVMSG                      |Sanjeev                      |---    
 CB0000131     |JET Systems, LLC           |Nathan Nametka               |myjetsystems.com   |Custom Carrier Board             |nnametka
 CB0000132     |NUST AirWorks              |Aamir                        |---                |Custom Carrier Board             |speed-str
 CB0000133     |Altium, Inc                |Andrew C. Smith              |upverter.com       |Upverter Customer Carrier Boards |smithandrewc
+CB0000134     |CiS GmbH                   |Tom Kaufmann                 |cis-rostock.de     |Custom Carrier Board             |therealkaufmann


### PR DESCRIPTION
We would like to request permission to use the Cube's footprint on a custom carrier board.