### PR TITLE
Update Carrier board footprint approval

### DIFF
--- a/CB_REV_C_Altium/Carrier board footprint approval
+++ b/CB_REV_C_Altium/Carrier board footprint approval
@@ -231,4 +231,5 @@ CB0000211     |Axldrone                   |Ananthu Aniyan               |www.axl
 CB0000212     |Airgence                   |Lewis Marsh                  |Airgence.co.uk      | Custom carrier board           |AirgenceUK
 CB0000213     |Private                    |Kyle Weiss                   |----                | Custom carrier board           |kweiss18
 CB0000214     |Eight Aero                 |Ryan Bohm                    |eight.aero          |Custom Carrier Board            |eightaero
-CB0000215     |GDC                 		  |Jake Vander Ploeg            |soargdc.com         |Custom Carrier Board            |jvanderploeg
+CB0000215     |GDC                 		    |Jake Vander Ploeg            |soargdc.com         |Custom Carrier Board            |jvanderploeg
+CB0000216     |VECROS                 		|Besta Prem Sai               |vecros.com          |JETCORE Flight Controller       |bestaps


### PR DESCRIPTION
JETCORE FC is extension of jetson carrier board that supports orin NX, Xavier Nx.