### PR TITLE
Update Aerium Carrier board footprint approval

### DIFF
--- a/CB_REV_C_Altium/Carrier board footprint approval
+++ b/CB_REV_C_Altium/Carrier board footprint approval
@@ -242,3 +242,4 @@ CB0000222     |Personal                   |Jordan Cormack               |cormack
 CB0000223     |Orb Aerospace              |Alex Konwerski               |orb.aero            |Custom Carrier board            |CapitaOrb
 CB0000224     |FlyingBasket               |Giacomo Cavasin              |flyingbasket.com    |Custom Carrier board            |giacomo30196
 CB0000225     |Aventra                    |Cobb Peterson                |aventra.io          |Custom Carrier board            |cobb-hub
+CB0000226     |Aerium                     |Yaad Chen                    |aerium.co.il        |Custom Carrier board            |aerium-systems


### PR DESCRIPTION
Aerium products, carrier boards for CubePilot
For example: https://aerium.co.il/products/aerium-altius