### PR TITLE
Add Drones Argentina X06 carrier board footprint license entry

### DIFF
--- a/CB_REV_C_Altium/Carrier board footprint approval
+++ b/CB_REV_C_Altium/Carrier board footprint approval
@@ -252,3 +252,4 @@ CB0000232     |UGR                        |Máté Koba                    |unexm
 CB0000233     |SARA Inc.                  |Jason Bockelmann             |sara.com            |Custom Carrier Board            |jb-sara  
 CB0000234     |Asylon, Incorporated       |Eric Timmons                 |asylonrobotics.com  |Custom Carrier Board            |daewok
 CB0000235     |Acecore Technologies       |Max                          |acecoretechnologies.com   |Custom Carrier Board      |Max-002
+CB0000236     |Drones Argentina           |Santiago Bernardi            |dronesargentina.com.ar  |Custom Carrier Board        |Drones Argentina


### PR DESCRIPTION
Adding a new line to CB_REV_C_Altium/Carrier board footprint approval to request a license to use the Cube carrier board footprint.